### PR TITLE
#3 Grade reduction by percent in logs implemented

### DIFF
--- a/common.py
+++ b/common.py
@@ -400,6 +400,22 @@ def get_task_id(log):
     return int(log[i:i+2].strip())
 
 
+def get_grade_reduction_coefficient(log):
+    reduction_str = "Grading reduced by"
+    i = log.find(reduction_str)
+    if i < 0:
+        return None
+    i += len(reduction_str) + 1
+    reduction_percent = int(log[i:log.find("%")].strip())
+    if reduction_percent == 0:
+        return None
+    else:
+        # 0.01 * (100 - REDUCTION_PERCENT) = REDUCTION_COEFFICIENT in decimal form
+        # return 0.01 * (100 - reduction_percent) # pure float coefficient
+        # for current case, where percents could be in range [1; 100], using of 'g' format is OK
+        return '{0:g}'.format(0.01 * (100 - reduction_percent))
+
+
 def github_get_file(repo, filepath):
     """
     get a single file from GitHub

--- a/main.py
+++ b/main.py
@@ -193,16 +193,26 @@ def check_lab(lab_id, groups, data, data_update=[]):
                 google_sheets.set_student_lab_status(data, student, lab_id_int, "?! Wrong TASKID!", data_update=data_update)
             else:
                 # everything looks good, go on and update lab status
+                # calculate grade reduction coefficient
+                reduction_coefficient_str = common.get_grade_reduction_coefficient(log)
+                if reduction_coefficient_str is not None:
+                    grade_reduction_suffix = "*{}".format(reduction_coefficient_str)
+                else:
+                    grade_reduction_suffix = ""
+                # calculate deadline penalty
                 student_dt = isoparse(completion_date)
                 if student_dt > deadlines[student['group']]:
                     overdue = student_dt - deadlines[student['group']]
                     penalty = math.ceil((overdue.days + overdue.seconds / 86400) / 7)
                     # TODO: check that penalty does not exceed maximum grade points for that lab
                     penalty = min(penalty, settings.os_labs[lab_id].get('penalty_max', 0))
-                    suffix = "-{}".format(penalty)
+                    penalty_suffix = "-{}".format(penalty)
                 else:
-                    suffix = ""
-                google_sheets.set_student_lab_status(data, student, lab_id_int, "v{}".format(suffix), data_update=data_update)
+                    penalty_suffix = ""
+                # update status
+                google_sheets.set_student_lab_status(data, student, lab_id_int,
+                                                     "v{}{}".format(grade_reduction_suffix, penalty_suffix),
+                                                     data_update=data_update)
     return data_update
 
 


### PR DESCRIPTION
Resolves #3 

В текущем дизайне имеется потенциальная проблема, которая касается возможности получения студентом отрицательного балла за ЛР. Например, при проценте снижения `100` (если такой вообще будет возможен) ячейка будет выглядеть как `v*0`, если нет штрафов за сроки выполнения, и как `v*0-x` в случае несоблюдения сроков на `x` недель, что фактически выглядит как получение `-x` баллов за ЛР.
Аналогичную ситуацию с отрицательными баллами за ЛР можно также получить удачной комбинацией процента снижения и количества вычитаемых баллов за нарушение сроков. Например, в случае значения `v*0.5-5` и "стоимости" ЛР в `8` баллов, за ЛР уже потенциально получается `-1` балл.

Также, допускаю, что описанная выше ситуация не критична и в случае её возникновения должна "by design" обрабатываться вручную. Если так, то всё ОК.